### PR TITLE
修复：1、当挂载有widget组件，并且在UI start方法中创建并reloadData时，scrollView的尺寸有可能获取错误（w…

### DIFF
--- a/list-3x/assets/lib/yx-collection-view.ts
+++ b/list-3x/assets/lib/yx-collection-view.ts
@@ -574,7 +574,7 @@ export class YXCollectionView extends Component {
 
             let transform = content.getComponent(UITransform) || content.addComponent(UITransform)
             transform.contentSize = this.node.getComponent(UITransform).contentSize
-            this.getComponent(Widget).updateAlignment?.();
+            this.getComponent(Widget)?.updateAlignment?.();
             result.content = content
         }
 

--- a/list-3x/assets/lib/yx-collection-view.ts
+++ b/list-3x/assets/lib/yx-collection-view.ts
@@ -1,4 +1,4 @@
-import { _decorator, Component, Enum, Event, EventMouse, EventTouch, instantiate, Mask, math, Node, NodeEventType, NodePool, Prefab, ScrollView, UIOpacity, UITransform } from 'cc';
+import { _decorator, Component, Enum, Event, EventMouse, EventTouch, instantiate, Mask, math, Node, NodeEventType, NodePool, Prefab, ScrollView, UIOpacity, UITransform, Widget } from 'cc';
 const { ccclass, property, executionOrder, disallowMultiple, help } = _decorator;
 
 const _vec3Out = new math.Vec3()
@@ -294,6 +294,17 @@ class _scroll_view extends ScrollView {
         }
         return result
     }
+
+    set content(value) {
+        super.content = value;
+        if (value) {
+            value.on(NodeEventType.SIZE_CHANGED, this._calculateBoundary, this);
+            value.on(NodeEventType.TRANSFORM_CHANGED, this._scaleChanged, this);
+        }
+    }
+    get content() {
+        return super.content;
+    }
 }
 
 class _yx_node_pool extends NodePool {
@@ -563,7 +574,7 @@ export class YXCollectionView extends Component {
 
             let transform = content.getComponent(UITransform) || content.addComponent(UITransform)
             transform.contentSize = this.node.getComponent(UITransform).contentSize
-
+            this.getComponent(Widget).updateAlignment?.();
             result.content = content
         }
 
@@ -919,6 +930,7 @@ export class YXCollectionView extends Component {
      */
     reloadData() {
         if (this.node.activeInHierarchy && this.node.parent) {
+            // this.getComponent(Widget).updateAlignment?.();
             this._reloadData()
             return
         }

--- a/list-3x/assets/lib/yx-collection-view.ts
+++ b/list-3x/assets/lib/yx-collection-view.ts
@@ -296,14 +296,14 @@ class _scroll_view extends ScrollView {
     }
 
     set content(value) {
-        super.content = value;
+        Reflect.set(ScrollView.prototype, 'content', value, this);
         if (value) {
             value.on(NodeEventType.SIZE_CHANGED, this._calculateBoundary, this);
             value.on(NodeEventType.TRANSFORM_CHANGED, this._scaleChanged, this);
         }
     }
     get content() {
-        return super.content;
+        return Reflect.get(ScrollView.prototype, 'content', this);
     }
 }
 
@@ -930,7 +930,6 @@ export class YXCollectionView extends Component {
      */
     reloadData() {
         if (this.node.activeInHierarchy && this.node.parent) {
-            // this.getComponent(Widget).updateAlignment?.();
             this._reloadData()
             return
         }


### PR DESCRIPTION
修复：1、当挂载有widget组件，并且在UI start方法中创建并reloadData时，scrollView的尺寸有可能获取错误（widget未update前的尺寸）的问题，2、挂载widget并尺寸发生变化时，content的位置等没法重新计算的问题（创建并赋值scrollview content最早是在onLoad，在此之前的onEnable回调中content若为空是不会监听到事件的 via:https://github.com/cocos/cocos-engine/blob/dbae22d3498d91e49712b766b2587b8d68e4ddd2/cocos/ui/scroll-view.ts#L997）